### PR TITLE
fixed bug converting mapping array arguments to map.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -161,9 +161,15 @@ exports.allServices = function() {
 
 function arrayToObject(a) {
   // convert ['a', 2, 'b', 4] => {'a': 2, 'b': 4}.
-  return _.object(
+  var object = _.object(
     _.toArray(
       _.groupBy(a, function(v, i) {return Math.floor(i / 2);})
     )
   );
+
+  // get rid of undefined values.
+  return _.reduce(object, function(result, v, k) {
+    var value = typeof v === 'undefined' ? '' : v;
+    return (result[k] = value, result)
+  }, {});
 }

--- a/service.json
+++ b/service.json
@@ -16,7 +16,7 @@
     "env": {
       "PORT": 8080
     },
-    "args": ["--apple", "banana", "--spider-man", "sad"]
+    "args": ["--apple", "banana", "--spider-man", "sad", "awesome"]
   },
   "env": {
     "APP": "my-test-app"

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -44,6 +44,12 @@ Lab.experiment('service', function() {
       Lab.expect(service.args['--apple']).to.eql('banana');
       done();
     });
+
+    Lab.it('should handle flags, without creating undefined arguments', function(done) {
+      var service = Service.allServices()[1];
+      Lab.expect(service.args.awesome).to.not.be.undefined;
+      done();
+    });
   });
 
   Lab.experiment('commands', function() {


### PR DESCRIPTION
having an uneven # of args in an array results in adding an 'undefined' argument to generated scripts.
