### PR TITLE
refactoring ndm to use scripts rather than bin

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -46,7 +46,7 @@ Installer.prototype._generateServiceJson = function(update) {
   if (!packageJson.dependencies) throw Error('no services found, add dependencies to package.json.');
 
   // walk all the dependencies in package.json, and copy
-  // env, args, and bin into default serviceJson.
+  // env, args, and scripts into default serviceJson.
   Object.keys(packageJson.dependencies).forEach(function(module) {
     var moduleDirectory = path.resolve(
         _this.baseWorkingDirectory,
@@ -61,7 +61,7 @@ Installer.prototype._generateServiceJson = function(update) {
 
     if (!servicesJson[module]) servicesJson[module] = {
       description: moduleJson.description,
-      bin: serviceJson.bin ? moduleJson.bin[serviceJson.bin] : 'start',
+      scripts: removeNodeBin(moduleJson.scripts) || {},
       env: serviceJson.env || {},
       args: serviceJson.args || {},
     }
@@ -96,6 +96,15 @@ Installer.prototype._printInitMessage = function() {
   logger.log("when you're ready, run 'ndm generate' to generate service wrappers.");
   logger.log("add dependencies to 'package.json' and run 'ndm update' to add additional services.");
   logger.success("\nsuccess!");
+};
+
+// remove references to the node bin from scripts,
+// the service wrappers we genearte add it back with an
+// absolute execution path.
+function removeNodeBin(o) {
+  return _.reduce(o, function(result, v, k) {
+    return (result[k] = v.replace(/^node +/, ''), result)
+  }, {});
 };
 
 module.exports = Installer;

--- a/lib/script.js
+++ b/lib/script.js
@@ -1,0 +1,15 @@
+// run a command in the context of the environment and
+// args described in service.json.
+var _ = require('lodash'),
+  logger = require('./logger');
+
+function Script(opts) {
+  _.extend(this,
+    {
+    },
+    require('./config')(),
+    opts
+  );
+}
+
+exports.module = Script;

--- a/node_modules/ndm-test/package.json
+++ b/node_modules/ndm-test/package.json
@@ -1,18 +1,14 @@
 {
   "name": "ndm-test",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Test program for ndm deployment library.",
   "main": "test.js",
-  "bin": {
-    "ndm-test": "test.js"
-  },
   "scripts": {
     "start": "node ./test.js"
   },
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "ndm": {
-    "bin": "ndm-test",
     "args": {
       "--verbose": "false",
       "--host": {

--- a/service.json
+++ b/service.json
@@ -1,7 +1,9 @@
 {
   "ndm-test": {
     "description": "thumbnailing service",
-    "bin": "./test.js",
+    "scripts": {
+      "start": "./test.js"
+    },
     "env": {
       "PORT": 8000,
       "USER": "bcoe"
@@ -19,7 +21,9 @@
     }
   },
   "ndm-test2": {
-    "bin": "./test.js",
+    "scripts": {
+      "start": "./test.js"
+    },
     "module": "ndm-test",
     "env": {
       "PORT": 8080,

--- a/templates/launchctl.ejs
+++ b/templates/launchctl.ejs
@@ -9,7 +9,7 @@
     <key>ProgramArguments</key>
     <array>
       <string><%= nodeBin %></string>
-      <string><%= bin %></string><% Object.keys(args).forEach(function(key) { %>
+      <string><%= scripts.start %></string><% Object.keys(args).forEach(function(key) { %>
       <string><%= key %></string>
       <string><%= args[key]  %></string><% }); %>
     </array>

--- a/templates/upstart-centos.ejs
+++ b/templates/upstart-centos.ejs
@@ -9,5 +9,5 @@ limit nofile 1000000 1000000
 script<% if (uid) { %>
   su - <%= uid %><% } %>
   cd <%= workingDirectory %>
-  <% Object.keys(env).forEach(function(key) {%><%= key %>=<%= env[key] %> <% }); %><%= nodeBin %> <%= bin %><% Object.keys(args).forEach(function(key) { %> <%= key %> <%= args[key] %><% }); %> >> <%= logFile %> 2>&1
+  <% Object.keys(env).forEach(function(key) {%><%= key %>=<%= env[key] %> <% }); %><%= nodeBin %> <%= scripts.start %><% Object.keys(args).forEach(function(key) { %> <%= key %> <%= args[key] %><% }); %> >> <%= logFile %> 2>&1
 end script

--- a/templates/upstart-ubuntu.ejs
+++ b/templates/upstart-ubuntu.ejs
@@ -11,7 +11,7 @@ console log
 
 script
   cd <%= workingDirectory %>
-  <% Object.keys(env).forEach(function(key) {%><%= key %>=<%= env[key] %> <% }); %><%= nodeBin %> <%= bin %><% Object.keys(args).forEach(function(key) { %> <%= key %> <%= args[key] %><% }); %> >> <%= logFile %> 2>&1
+  <% Object.keys(env).forEach(function(key) {%><%= key %>=<%= env[key] %> <% }); %><%= nodeBin %> <%= scripts.start %><% Object.keys(args).forEach(function(key) { %> <%= key %> <%= args[key] %><% }); %> >> <%= logFile %> 2>&1
 end script
 
 respawn

--- a/test/fixtures/node_modules/ndm-test/package.json
+++ b/test/fixtures/node_modules/ndm-test/package.json
@@ -1,11 +1,8 @@
 {
   "name": "ndm-test",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Test program for ndm deployment library.",
   "main": "test.js",
-  "bin": {
-    "ndm-test": "test.js"
-  },
   "scripts": {
     "start": "node ./test.js"
   },
@@ -15,7 +12,6 @@
   },
   "license": "ISC",
   "ndm": {
-    "bin": "ndm-test",
     "args": {
       "--verbose": "false",
       "--host": {
@@ -30,10 +26,10 @@
   "dependencies": {
     "yargs": "^1.2.6"
   },
-  "_id": "ndm-test@0.0.8",
-  "_shasum": "37ec0e8135c27db95c7dad4449397eb76b887b2f",
-  "_from": "ndm-test@0.0.8",
-  "_npmVersion": "1.4.16",
+  "_id": "ndm-test@0.0.9",
+  "_shasum": "a30518609b21a01c41573a7c613a623a51b90f1e",
+  "_from": "ndm-test@0.0.9",
+  "_npmVersion": "1.4.17",
   "_npmUser": {
     "name": "bcoe",
     "email": "bencoe@gmail.com"
@@ -45,9 +41,9 @@
     }
   ],
   "dist": {
-    "shasum": "37ec0e8135c27db95c7dad4449397eb76b887b2f",
-    "tarball": "http://registry.npmjs.org/ndm-test/-/ndm-test-0.0.8.tgz"
+    "shasum": "a30518609b21a01c41573a7c613a623a51b90f1e",
+    "tarball": "http://registry.npmjs.org/ndm-test/-/ndm-test-0.0.9.tgz"
   },
   "directories": {},
-  "_resolved": "https://registry.npmjs.org/ndm-test/-/ndm-test-0.0.8.tgz"
+  "_resolved": "https://registry.npmjs.org/ndm-test/-/ndm-test-0.0.9.tgz"
 }

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -5,6 +5,6 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
-    "ndm-test": "0.0.8"
+    "ndm-test": "0.0.9"
   }
 }

--- a/test/installer-test.js
+++ b/test/installer-test.js
@@ -85,7 +85,7 @@ Lab.experiment('installer', function() {
         fs.readFileSync('./test/fixtures/service.json').toString()
       );
 
-      Lab.expect(serviceJson['ndm-test'].bin).to.eql('test.js');
+      Lab.expect(serviceJson['ndm-test'].scripts.start).to.eql('./test.js');
       done();
     });
   });


### PR DESCRIPTION
- refactoring ndm to use the scripts stanza rather than the bin stanza (I think this is clearer).
- adding the ability to run scripts in the context of the environment described in service.json.
