### PR TITLE
multiple services in a global package

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,7 @@ function Config(opts) {
     modulePrefix: '/usr/local',
     nodeBin: process.execPath,
     baseWorkingDirectory: path.resolve(process.cwd()),
+    globalPackage: false,
     releaseInfoFile: '/etc/redhat-release'
   }, opts);
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -290,7 +290,8 @@ exports.transformPackageJson = function(packageJson) {
 // services, they have a slightly different format than
 // package.json.
 function parseServiceJson(serviceNameFilter, serviceJson) {
-  var services = [];
+  var services = [],
+    config = require('./config')();
 
   Object.keys(serviceJson).forEach(function(serviceName) {
     if (serviceName === 'env' || serviceName === 'args') return;
@@ -329,7 +330,7 @@ function parseServiceJson(serviceNameFilter, serviceJson) {
     }
 
     // we can optionall filter to a specific service name.
-    if (serviceNameFilter && service.name !== serviceNameFilter) return;
+    if (serviceNameFilter && service.name !== serviceNameFilter && !config.globalPackage) return;
 
     services.push(service);
   });
@@ -386,6 +387,9 @@ exports._serviceJsonPath = function(serviceNameFilter) {
     if (config.logsDirectory === config.defaultLogsDirectory()) {
       config.logsDirectory = config.osLogsDirectory;
     }
+
+    //use global interpretation of commands: ndm <cmd> <global-package>
+    config.globalPackage = true;
   };
 
   return config.serviceJsonPath;


### PR DESCRIPTION
For global packages `allServices(serviceNameFilter)` was only returning services that had the same name as the package itself. `ndm-test` got by this because its only service is `ndm-test`.

The reason is because `parseServiceJson` was throwing out services that didn't have the same name as `serviceNameFilter`. If you are using `ndm` for a local package than this makes sense because `serviceNameFilter` is supposed to be the name of the only service which you want to use. But for global packages `serviceNameFilter` is the name of the actual global package, and so we should instead operate on all services.

I pulled this off by adding `config.globalPackage` because I figured the change in application behavior by being global was enough to keep that fact around.
