### PR TITLE
Generic restart command

### DIFF
--- a/lib/platform-apis/platform-base.js
+++ b/lib/platform-apis/platform-base.js
@@ -10,7 +10,8 @@ function PlatformBase(opts) {
     platform: null,
     // path to template to use for service generation,
     // use of a template may be optional.
-    template: null
+    template: null,
+    logger: require('../logger')
   }, opts);
 }
 
@@ -67,7 +68,7 @@ PlatformBase.prototype.restart = function(service, cb) {
 
   self.stop(service, function(error)
   {
-    if(error) return cb(error);
+    if(error) self.logger.error(error.message);
     
     self.start(service, cb);
   });


### PR DESCRIPTION
The most generic restart command is to stop and start a service, so it's not necesary to make mandatory to define one.
