### PR TITLE
Updated lab to the latest version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "bin": "./bin/ndm.js",
   "scripts": {
-    "test": "lab -c --timeout=8000"
+    "test": "lab -c --timeout 8000"
   },
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
@@ -24,7 +24,7 @@
     "yargs": "^1.3.1"
   },
   "devDependencies": {
-    "lab": "^3.2.1",
+    "lab": "~4.5.1",
     "mocha": "^1.20.0"
   },
   "repository": {

--- a/test/cli-self-install.js
+++ b/test/cli-self-install.js
@@ -1,14 +1,16 @@
 require('../lib/config')({headless: true}); // turn off output in tests.
 
-var Lab = require('lab'),
-  path = require('path'),
-  _ = require('lodash');
+var lab = require('lab'),
+  Lab    = exports.lab = lab.script(),
+  expect = lab.expect,
+  path   = require('path'),
+  _      = require('lodash');
 
 Lab.experiment('cli-self-install', function() {
   Lab.experiment('init', function() {
     Lab.it('should infer module name based on package.json', function(done) {
       var ndm = require('../lib')('ndm-test');
-      Lab.expect(ndm.filter).to.eql('ndm-test');
+      expect(ndm.filter).to.eql('ndm-test');
       done();
     });
 
@@ -16,7 +18,7 @@ Lab.experiment('cli-self-install', function() {
       var ndm = require('../lib')('ndm-test', {
         logsDirectory: '/foo/logs'
       });
-      Lab.expect(ndm.logsDirectory).to.eql('/foo/logs');
+      expect(ndm.logsDirectory).to.eql('/foo/logs');
       done();
     });
   });

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,6 +1,8 @@
 require('../lib/config')({headless: true}); // turn off output in tests.
 
-var Lab = require('lab'),
+var lab = require('lab'),
+  Lab = exports.lab = lab.script(),
+  expect = lab.expect,
   Cli = require('../lib/cli'),
   _ = require('lodash');
 
@@ -16,8 +18,8 @@ Lab.experiment('cli', function() {
 
       var config = require('../lib/config')();
 
-      Lab.expect(config.sudo).to.eql(false);
-      Lab.expect(config.globalPackage).to.eql(true);
+      expect(config.sudo).to.eql(false);
+      expect(config.globalPackage).to.eql(true);
 
       done();
     });
@@ -35,7 +37,7 @@ Lab.experiment('cli', function() {
 
       cli.updateConfigWithNpmconf(npmconf);
       var config = require('../lib/config')();
-      Lab.expect(config.modulePrefix).to.eql('./test/fixtures');
+      expect(config.modulePrefix).to.eql('./test/fixtures');
 
       done();
     })
@@ -50,13 +52,13 @@ Lab.experiment('cli', function() {
       var help = cli.yargs.help();
 
       // generations option.
-      Lab.expect(help).to.match(/-u/);
+      expect(help).to.match(/-u/);
       // generates alias.
-      Lab.expect(help).to.match(/-sudo/);
+      expect(help).to.match(/-sudo/);
       // generates description.
-      Lab.expect(help).to.match(/where does the node executable reside/)
+      expect(help).to.match(/where does the node executable reside/)
       // generates defaults.
-      Lab.expect(help).to.match(/default: .*service\.json/);
+      expect(help).to.match(/default: .*service\.json/);
 
       done();
     });
@@ -68,7 +70,7 @@ Lab.experiment('cli', function() {
 
       var help = cli.yargs.help();
 
-      Lab.expect(help).to.match(/ndm generate/);
+      expect(help).to.match(/ndm generate/);
 
       done();
     });
@@ -80,7 +82,7 @@ Lab.experiment('cli', function() {
         yargs: require('yargs')([]),
         logger: {
           log: function(str) {
-            Lab.expect(str).to.match(/Usage:/);
+            expect(str).to.match(/Usage:/);
             done();
           }
         }
@@ -94,7 +96,7 @@ Lab.experiment('cli', function() {
         yargs: require('yargs')(['generate', '--help']),
         logger: {
           log: function(str) {
-            Lab.expect(str).to.match(/Usage:/);
+            expect(str).to.match(/Usage:/);
             done();
           }
         }
@@ -109,7 +111,7 @@ Lab.experiment('cli', function() {
         logger: {
           error: function(str) {},
           log: function(str) {
-            Lab.expect(str).to.match(/Usage:/);
+            expect(str).to.match(/Usage:/);
             done();
           }
         }
@@ -125,7 +127,7 @@ Lab.experiment('cli', function() {
       var cli = Cli({
         yargs: require('yargs')(['generate']),
         generate: function(serviceName) {
-          Lab.expect(serviceName).to.be.undefined;
+          expect(serviceName).to.be.undefined;
           done();
         }
       });
@@ -137,7 +139,7 @@ Lab.experiment('cli', function() {
       var cli = Cli({
         yargs: require('yargs')(['start', 'foobar']),
         start: function(serviceName) {
-          Lab.expect(serviceName).to.eql('foobar');
+          expect(serviceName).to.eql('foobar');
           done();
         }
       });
@@ -153,13 +155,13 @@ Lab.experiment('cli', function() {
         {
           name: 'service1',
           runCommand: function(command) {
-            Lab.expect(command).to.eql('start');
+            expect(command).to.eql('start');
           }
         },
         {
           name: 'service2',
           runCommand: function(command) {
-            Lab.expect(command).to.eql('start');
+            expect(command).to.eql('start');
             done();
           }
         }
@@ -186,7 +188,7 @@ Lab.experiment('cli', function() {
         {
           name: 'service2',
           runCommand: function(command) {
-            Lab.expect(command).to.eql('start');
+            expect(command).to.eql('start');
             done();
           }
         }
@@ -212,14 +214,14 @@ Lab.experiment('cli', function() {
           name: 'service1',
           hasScript: function() { return true; },
           runScript: function(command) {
-            Lab.expect(command).to.eql('foo-script');
+            expect(command).to.eql('foo-script');
           }
         },
         {
           name: 'service2',
           hasScript: function() { return true; },
           runScript: function(command) {
-            Lab.expect(command).to.eql('foo-script');
+            expect(command).to.eql('foo-script');
             done();
           }
         }
@@ -252,7 +254,7 @@ Lab.experiment('cli', function() {
           name: 'service2',
           hasScript: function() { return true; },
           runScript: function(command) {
-            Lab.expect(command).to.eql('foo-script');
+            expect(command).to.eql('foo-script');
             done();
           }
         }
@@ -275,7 +277,7 @@ Lab.experiment('cli', function() {
     Lab.it('runs an interview with a temporary service.json path', function(done) {
       // A mock Interview object.
       var FakeInterview = function(opts) {
-        Lab.expect(opts.tmpServiceJsonPath).to.match(/.*\.json/)
+        expect(opts.tmpServiceJsonPath).to.match(/.*\.json/)
         done();
       };
       FakeInterview.prototype.run = function() {};
@@ -325,7 +327,7 @@ Lab.experiment('cli', function() {
       var cli = Cli({
         rimraf: {
           sync: function(path) {
-            Lab.expect(path).to.eql(serviceJsonPath);
+            expect(path).to.eql(serviceJsonPath);
             done();
           }
         },

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -1,14 +1,16 @@
 var _ = require('lodash'),
-  Lab = require('lab'),
-  path = require('path'),
+  lab    = require('lab'),
+  Lab    = exports.lab = lab.script(),
+  expect = lab.expect,
+  path   = require('path'),
   Centos = require('../lib/platform-apis/centos'),
   Config = require('../lib/config'),
-  util = require('util');
+  util   = require('util');
 
 Lab.experiment('config', function() {
   Lab.it('should be initialized with sane defaults', function(done) {
     var config = Config();
-    Lab.expect(config.baseWorkingDirectory).to.match(/ndm/);
+    expect(config.baseWorkingDirectory).to.match(/ndm/);
     done();
   });
 
@@ -16,15 +18,15 @@ Lab.experiment('config', function() {
     var config = Config({
       baseWorkingDirectory: '/banana'
     });
-    Lab.expect(config.baseWorkingDirectory).to.eql('/banana');
+    expect(config.baseWorkingDirectory).to.eql('/banana');
     done();
   });
-  
+
   Lab.it('should allow defaults to be overridden by environment variables', function(done) {
     var config = Config({
       env: {NDM_BASE_WORKING_DIRECTORY: '/foo'}
     });
-    Lab.expect(config.baseWorkingDirectory).to.eql('/foo');
+    expect(config.baseWorkingDirectory).to.eql('/foo');
     done();
   });
 
@@ -32,7 +34,7 @@ Lab.experiment('config', function() {
     var config = Config({
       platform: 'darwin'
     });
-    Lab.expect(config.daemonsDirectory).to.eql('~/Library/LaunchAgents/');
+    expect(config.daemonsDirectory).to.eql('~/Library/LaunchAgents/');
     done();
   });
 
@@ -41,7 +43,7 @@ Lab.experiment('config', function() {
       platform: 'darwin',
       daemonsDirectory: '/foo'
     });
-    Lab.expect(config.daemonsDirectory).to.eql('/foo');
+    expect(config.daemonsDirectory).to.eql('/foo');
     done();
   });
 
@@ -52,7 +54,7 @@ Lab.experiment('config', function() {
 
     var config = (require('../lib/config'))();
 
-    Lab.expect(config.platform).to.eql('banana');
+    expect(config.platform).to.eql('banana');
     done();
   });
 
@@ -73,13 +75,13 @@ Lab.experiment('config', function() {
       }
     });
 
-    Lab.expect(config.platform).to.eql('centos');
+    expect(config.platform).to.eql('centos');
     done();
   });
 
   Lab.it('should read .ndmrc, and allow default settings to be overridden', function(done) {
     var config = Config();
-    Lab.expect(config.releaseInfoFile).to.eql('/foo/bar/release');
+    expect(config.releaseInfoFile).to.eql('/foo/bar/release');
     done();
   });
 });

--- a/test/installer-test.js
+++ b/test/installer-test.js
@@ -1,9 +1,11 @@
 require('../lib/config')({headless: true}); // turn off output in tests.
 
-var Lab = require('lab'),
+var lab = require('lab'),
+  Lab       = exports.lab = lab.script(),
+  expect    = lab.expect,
   Installer = require('../lib/installer'),
-  fs = require('fs'),
-  rimraf = require('rimraf');
+  fs        = require('fs'),
+  rimraf    = require('rimraf');
 
 Lab.experiment('installer', function() {
 
@@ -24,7 +26,7 @@ Lab.experiment('installer', function() {
     Lab.it('should raise an exception if service.json already exists', function(done) {
       var installer = new Installer();
 
-      Lab.expect(function() {
+      expect(function() {
         installer.init();
       }).to.throw(Error, /service\.json already exists/);
 
@@ -38,7 +40,7 @@ Lab.experiment('installer', function() {
       });
 
       installer.init();
-      Lab.expect(fs.existsSync('./test/fixtures/logs')).to.eql(true);
+      expect(fs.existsSync('./test/fixtures/logs')).to.eql(true);
 
       done();
     });
@@ -55,10 +57,10 @@ Lab.experiment('installer', function() {
         fs.readFileSync('./test/fixtures/service.json').toString()
       );
 
-      Lab.expect(serviceJson['ndm-test'].description).to.eql('Test program for ndm deployment library.');
-      Lab.expect(serviceJson['ndm-test'].env['PORT']).to.eql(5000);
-      Lab.expect(serviceJson['ndm-test'].args['--verbose']).to.eql('false');
-      Lab.expect(serviceJson['ndm-test'].args['--host']).to.eql({
+      expect(serviceJson['ndm-test'].description).to.eql('Test program for ndm deployment library.');
+      expect(serviceJson['ndm-test'].env['PORT']).to.eql(5000);
+      expect(serviceJson['ndm-test'].args['--verbose']).to.eql('false');
+      expect(serviceJson['ndm-test'].args['--host']).to.eql({
         default: '0.0.0.0',
         description: 'what host should we bind to?'
       });
@@ -72,7 +74,7 @@ Lab.experiment('installer', function() {
         serviceJsonPath: './test/fixtures/service.json'
       });
 
-      Lab.expect(function() {
+      expect(function() {
         installer.init();
       }).to.throw(Error, /package\.json did not exist/);
       done();
@@ -90,7 +92,7 @@ Lab.experiment('installer', function() {
         fs.readFileSync('./test/fixtures/service.json').toString()
       );
 
-      Lab.expect(serviceJson['ndm-test'].scripts.start).to.eql('node ./test.js');
+      expect(serviceJson['ndm-test'].scripts.start).to.eql('node ./test.js');
       done();
     });
 
@@ -106,7 +108,7 @@ Lab.experiment('installer', function() {
         fs.readFileSync('./test/fixtures/service.json').toString()
       );
 
-      Lab.expect(serviceJson['ndm-test'].scripts.thumbd).to.eql('./test3.js');
+      expect(serviceJson['ndm-test'].scripts.thumbd).to.eql('./test3.js');
       done();
     });
 
@@ -122,8 +124,8 @@ Lab.experiment('installer', function() {
         fs.readFileSync('./test/fixtures/service.json').toString()
       );
 
-      Lab.expect(serviceJson['@npm/ndm-test2']).to.be.undefined;
-      Lab.expect(serviceJson['ndm-test2'].module).to.eql('@npm/ndm-test2');
+      expect(serviceJson['@npm/ndm-test2']).to.be.undefined;
+      expect(serviceJson['ndm-test2'].module).to.eql('@npm/ndm-test2');
 
       done();
     });
@@ -150,12 +152,12 @@ Lab.experiment('installer', function() {
       );
 
       // should add new service.
-      Lab.expect(serviceJson['ndm-test'].description).to.eql('Test program for ndm deployment library.');
-      Lab.expect(serviceJson['ndm-test'].env['PORT']).to.eql(5000);
-      Lab.expect(serviceJson['ndm-test'].args['--verbose']).to.eql('false');
+      expect(serviceJson['ndm-test'].description).to.eql('Test program for ndm deployment library.');
+      expect(serviceJson['ndm-test'].env['PORT']).to.eql(5000);
+      expect(serviceJson['ndm-test'].args['--verbose']).to.eql('false');
 
       // should leave old service.
-      Lab.expect(serviceJson['app'].env['foo']).to.eql('bar');
+      expect(serviceJson['app'].env['foo']).to.eql('bar');
 
       done();
     });
@@ -179,7 +181,7 @@ Lab.experiment('installer', function() {
       );
 
       // should not clobber entries that already exist in service.json.
-      Lab.expect(serviceJson['ndm-test'].env['foo']).to.eql('bar');
+      expect(serviceJson['ndm-test'].env['foo']).to.eql('bar');
       done();
     });
   });

--- a/test/interview-test.js
+++ b/test/interview-test.js
@@ -1,10 +1,12 @@
 require('../lib/config')({headless: true}); // turn off output in tests.
 
-var Lab = require('lab'),
+var lab = require('lab'),
+  Lab       = exports.lab = lab.script(),
+  expect    = lab.expect,
   Interview = require('../lib/interview'),
   Installer = require('../lib/installer'),
-  rimraf = require('rimraf'),
-  fs = require('fs');
+  rimraf    = require('rimraf'),
+  fs        = require('fs');
 
 Lab.experiment('interview', function() {
 
@@ -14,7 +16,7 @@ Lab.experiment('interview', function() {
 
       interview._generateQuestions();
 
-      Lab.expect(
+      expect(
         interview.questionLookup['--frontdoor-url'].message
       ).to.eql('url of front facing server');
 
@@ -26,7 +28,7 @@ Lab.experiment('interview', function() {
 
       interview._generateQuestions();
 
-      Lab.expect(
+      expect(
         interview.questionLookup['ENVIRONMENT'].message
       ).to.eql('what environment should we run the app in');
 
@@ -39,7 +41,7 @@ Lab.experiment('interview', function() {
       interview._generateQuestions();
 
       // we handle two keys colliding by using a longer unique key.
-      Lab.expect(
+      expect(
         interview.questionLookup['--dog'].message
       ).to.eql('what do you think of dogs?');
 
@@ -52,7 +54,7 @@ Lab.experiment('interview', function() {
       interview._generateQuestions();
 
       // we handle two keys colliding by using a longer unique key.
-      Lab.expect(
+      expect(
         interview.questionLookup['HOST'].message
       ).to.eql('what host should I bind to?');
 
@@ -65,7 +67,7 @@ Lab.experiment('interview', function() {
       interview._generateQuestions();
 
       // we handle two keys colliding by using a longer unique key.
-      Lab.expect(
+      expect(
         interview.questionLookup['ndm-test:args:--frontdoor-url'].message
       ).to.eql('pork chop sandwiches');
 
@@ -115,7 +117,7 @@ Lab.experiment('interview', function() {
         fs.readFileSync('./test/fixtures/service.json').toString()
       );
 
-      Lab.expect(serviceJson['ndm-test'].args['--host']).to.eql('2.2.2.2');
+      expect(serviceJson['ndm-test'].args['--host']).to.eql('2.2.2.2');
 
       done();
     });
@@ -125,7 +127,7 @@ Lab.experiment('interview', function() {
       var interview = new Interview({
         logger: {
           error: function(msg) {
-            Lab.expect(msg).to.eql('aborted writing service.json');
+            expect(msg).to.eql('aborted writing service.json');
             done();
           }
         },
@@ -177,7 +179,7 @@ Lab.experiment('interview', function() {
         fs.readFileSync('/tmp/service.json').toString()
       );
 
-      Lab.expect(serviceJson['ndm-test'].args['--host']).to.eql('2.2.2.2');
+      expect(serviceJson['ndm-test'].args['--host']).to.eql('2.2.2.2');
 
       done();
     });

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,12 +1,14 @@
 require('../lib/config')({headless: true}); // turn off output in tests.
 
-var Lab = require('lab');
+var lab = require('lab'),
+  expect = lab.expect,
+  Lab = exports.lab = lab.script();
 
 Lab.experiment('logger', function() {
   Lab.experiment('errorLogged', function() {
     Lab.it('should return true if an error has been logged', function(done) {
       require('../lib/logger').error("I am an error.");
-      Lab.expect(require('../lib/logger').errorLogged()).to.eql(true);
+      expect(require('../lib/logger').errorLogged()).to.eql(true);
       done();
     });
   });

--- a/test/platform-apis/centos-test.js
+++ b/test/platform-apis/centos-test.js
@@ -1,7 +1,9 @@
 require('../../lib/config')({headless: true}); // turn off output in tests.
 
 var Centos = require('../../lib/platform-apis/centos'),
-  Lab = require('lab');
+  lab = require('lab'),
+  expect = lab.expect,
+  Lab = exports.lab = lab.script();
 
 Lab.experiment('centos', function() {
   Lab.experiment('isPlatform', function() {
@@ -9,7 +11,7 @@ Lab.experiment('centos', function() {
       var centos = new Centos({
         releaseInfoFile: './test/fixtures/redhat-release'
       });
-      Lab.expect(centos.isPlatform()).to.eql(true);
+      expect(centos.isPlatform()).to.eql(true);
       done();
     });
   });

--- a/test/platform-apis/platform-base-test.js
+++ b/test/platform-apis/platform-base-test.js
@@ -1,7 +1,9 @@
 require('../../lib/config')({headless: true}); // turn off output in tests.
 
 var PlatformBase = require('../../lib/platform-apis/platform-base').PlatformBase,
-  Lab = require('lab');
+  lab = require('lab'),
+  expect = lab.expect,
+  Lab = exports.lab = lab.script();
 
 Lab.experiment('platform-base', function() {
   Lab.experiment('restart', function() {
@@ -10,7 +12,7 @@ Lab.experiment('platform-base', function() {
       var platform = new PlatformBase({
         logger: {
           error: function(msg) {
-            Lab.expect(msg).to.eql('must implement stop()');
+            expect(msg).to.eql('must implement stop()');
             done();
           }
         }
@@ -27,7 +29,7 @@ Lab.experiment('platform-base', function() {
       });
 
       platform.restart('fake-service', function(err) {
-        Lab.expect(err.message).to.eql('must implement start()');
+        expect(err.message).to.eql('must implement start()');
         done();
       });
     });

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -1,108 +1,112 @@
 require('../lib/config')({headless: true}); // turn off output in tests.
 
 var Lab = require('lab'),
-  path = require('path'),
-  Config = require('../lib/config'),
-  Service = require('../lib/service'),
-  fs = require('fs');
+  lab      = exports.lab = Lab.script(),
+  describe = lab.describe,
+  it       = lab.it,
+  expect   = Lab.expect,
+  path     = require('path'),
+  Config   = require('../lib/config'),
+  Service  = require('../lib/service'),
+  fs       = require('fs');
 
-Lab.experiment('service', function() {
+lab.experiment('service', function() {
 
-  Lab.experiment('allServices', function() {
-    Lab.it('returns all services if no filter is provided', function(done) {
-      Lab.expect(Service.allServices().length).to.eql(3);
+  lab.experiment('allServices', function() {
+    it('returns all services if no filter is provided', function(done) {
+      expect(Service.allServices().length).to.eql(3);
       done();
     });
 
-    Lab.it('should filter a specific service if filter is argument is provided', function(done) {
+    it('should filter a specific service if filter is argument is provided', function(done) {
       var services = Service.allServices('ndm'),
         service = services[0];
 
-      Lab.expect(services.length).to.eql(1);
-      Lab.expect(service.name).to.eql('ndm');
+      expect(services.length).to.eql(1);
+      expect(service.name).to.eql('ndm');
 
       done();
     });
   });
 
-  Lab.experiment('env', function() {
-    Lab.it('should default module to service name, if no module stanza provided', function(done) {
+  lab.experiment('env', function() {
+    it('should default module to service name, if no module stanza provided', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.module).to.eql(service.name);
+      expect(service.module).to.eql(service.name);
       done();
     });
 
-    Lab.it('should allow npm-module to be overridden', function(done) {
+    it('should allow npm-module to be overridden', function(done) {
       var service = Service.allServices()[1];
-      Lab.expect(service.module).to.eql('ndm-test');
+      expect(service.module).to.eql('ndm-test');
       done();
     });
 
-    Lab.it('should load global environment stanza if present', function(done) {
+    it('should load global environment stanza if present', function(done) {
       var service = Service.allServices()[1];
-      Lab.expect(service.env.APP).to.eql('my-test-app');
+      expect(service.env.APP).to.eql('my-test-app');
       done();
     });
 
-    Lab.it('should handle object rather than value for service env', function(done) {
+    it('should handle object rather than value for service env', function(done) {
       var service = Service.allServices()[1];
-      Lab.expect(service.env.HOST).to.eql('localhost');
+      expect(service.env.HOST).to.eql('localhost');
       done();
     });
 
-    Lab.it('should handle object rather than value for global env', function(done) {
+    it('should handle object rather than value for global env', function(done) {
       var service = Service.allServices()[1];
-      Lab.expect(service.env.ENVIRONMENT).to.eql('test');
+      expect(service.env.ENVIRONMENT).to.eql('test');
       done();
     });
   });
 
-  Lab.experiment('args', function() {
-    Lab.it('should load the global args variable', function(done) {
+  lab.experiment('args', function() {
+    it('should load the global args variable', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.args['--batman']).to.eql('greatest-detective');
+      expect(service.args['--batman']).to.eql('greatest-detective');
       done();
     });
 
-    Lab.it('should override global args with service specific args', function(done) {
+    it('should override global args with service specific args', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.args['--dog']).to.eql('also-cute');
+      expect(service.args['--dog']).to.eql('also-cute');
       done();
     });
 
-    Lab.it('should handle an object rather than a value for service args', function(done) {
+    it('should handle an object rather than a value for service args', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.args['--dog']).to.eql('also-cute');
+      expect(service.args['--dog']).to.eql('also-cute');
       done();
     });
 
-    Lab.it('should handle an object rather than a value for global args', function(done) {
+    it('should handle an object rather than a value for global args', function(done) {
       var service = Service.allServices()[2];
-      Lab.expect(service.args['--frontdoor-url']).to.eql('http://127.0.0.1:8080');
+      expect(service.args['--frontdoor-url']).to.eql('http://127.0.0.1:8080');
       done();
     });
 
-    Lab.experiment('array arguments', function() {
-      Lab.it('should handle array args', function(done) {
+    lab.experiment('array arguments', function() {
+      it('should handle array args', function(done) {
         var service = Service.allServices()[1];
-        Lab.expect(service.args.indexOf('--apple')).to.be.gt(-1);
+        expect(service.args.indexOf('--apple')).to.be.gt(-1);
         done();
       });
 
-      Lab.it('should combine global args with service level args', function(done) {
+      it('should combine global args with service level args', function(done) {
         Config({
           serviceJsonPath: './test/fixtures/args-service.json'
         });
         var service = Service.allServices()[0];
-        Lab.expect(service.args[0]).to.eql('a');
-        Lab.expect(service.args.indexOf("--apple")).to.not.eql(-1);
+        expect(service.args[0]).to.eql('a');
+        expect(service.args.indexOf("--apple")).to.not.eql(-1);
         done();
       });
     });
   });
 
-  Lab.experiment('commands', function() {
-    Lab.it('should generate appropriate start/stop/restart commands for OSX', function(done) {
+  lab.experiment('commands', function() {
+    it('should generate appropriate start/stop/restart commands for OSX', function(done) {
       Config({
         platform: 'darwin',
         daemonsDirectory: './'
@@ -111,26 +115,26 @@ Lab.experiment('service', function() {
       var service = Service.allServices()[0];
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.match(/launchctl.*load.*/)
+        expect(command).to.match(/launchctl.*load.*/)
       };
 
       service.runCommand('start');
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.match(/launchctl.*unload.*launchctl.*load/)
+        expect(command).to.match(/launchctl.*unload.*launchctl.*load/)
       };
 
       service.runCommand('restart');
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.match(/launchctl.*unload.*/);
+        expect(command).to.match(/launchctl.*unload.*/);
       };
 
       service.runCommand('stop');
       done();
     });
 
-    Lab.it('should generate appropriate start/stop/restart commands for Centos', function(done) {
+    it('should generate appropriate start/stop/restart commands for Centos', function(done) {
       Config({
         platform: 'centos',
         daemonsDirectory: './'
@@ -139,19 +143,19 @@ Lab.experiment('service', function() {
       var service = Service.allServices()[0]
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.eql("initctl start ndm-test");
+        expect(command).to.eql("initctl start ndm-test");
       };
 
       service.runCommand('start');
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.eql("initctl restart ndm-test");
+        expect(command).to.eql("initctl restart ndm-test");
       };
 
       service.runCommand('restart');
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.eql("initctl stop ndm-test");
+        expect(command).to.eql("initctl stop ndm-test");
       };
 
       service.runCommand('stop');
@@ -159,7 +163,7 @@ Lab.experiment('service', function() {
       done();
     });
 
-    Lab.it('should generate appropriate start/stop/restart commands for Ubuntu', function(done) {
+    it('should generate appropriate start/stop/restart commands for Ubuntu', function(done) {
       Config({
         platform: 'ubuntu',
         daemonsDirectory: './'
@@ -168,19 +172,19 @@ Lab.experiment('service', function() {
       var service = Service.allServices()[0];
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.eql("service ndm-test start");
+        expect(command).to.eql("service ndm-test start");
       };
 
       service.runCommand('start');
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.eql("service ndm-test restart");
+        expect(command).to.eql("service ndm-test restart");
       };
 
       service.runCommand('restart');
 
       service.execCommand = function(command, cb) {
-        Lab.expect(command).to.eql("service ndm-test stop");
+        expect(command).to.eql("service ndm-test stop");
       };
 
       service.runCommand('stop');
@@ -190,28 +194,28 @@ Lab.experiment('service', function() {
 
   });
 
-  Lab.experiment('generateScript', function() {
+  lab.experiment('generateScript', function() {
 
     function sharedAssertions(script) {
       // local environment variables populated.
-      Lab.expect(script).to.match(/PORT/);
-      Lab.expect(script).to.match(/8000/);
+      expect(script).to.match(/PORT/);
+      expect(script).to.match(/8000/);
 
       // global environment variables populated.
-      Lab.expect(script).to.match(/APP/)
-      Lab.expect(script).to.match(/my-test-app/);
+      expect(script).to.match(/APP/)
+      expect(script).to.match(/my-test-app/);
 
       // local args varibles populated.
-      Lab.expect(script).to.match(/--kitten/);
-      Lab.expect(script).to.match(/cute/);
+      expect(script).to.match(/--kitten/);
+      expect(script).to.match(/cute/);
 
       // global ags variables populated.
-      Lab.expect(script).to.match(/--batman/);
-      Lab.expect(script).to.match(/greatest-detective/);
+      expect(script).to.match(/--batman/);
+      expect(script).to.match(/greatest-detective/);
     }
 
-    Lab.experiment('darwin', function() {
-      Lab.it('should genterate a script with the appropriate variables populated', function(done) {
+    lab.experiment('darwin', function() {
+      it('should genterate a script with the appropriate variables populated', function(done) {
         // test generating a script for darwin.
         Config({
           platform: 'darwin',
@@ -228,7 +232,7 @@ Lab.experiment('service', function() {
           sharedAssertions(script);
 
           // it should populate the bin for the script.
-          Lab.expect(script).to.match(/>.\/test.js/)
+          expect(script).to.match(/>.\/test.js/)
 
           done();
         });
@@ -236,9 +240,9 @@ Lab.experiment('service', function() {
       });
     });
 
-    Lab.experiment('centos', function() {
+    lab.experiment('centos', function() {
 
-      Lab.it('should genterate a script with the appropriate variables populated', function(done) {
+      it('should genterate a script with the appropriate variables populated', function(done) {
         Config({
           platform: 'centos',
           daemonsDirectory: './'
@@ -254,17 +258,17 @@ Lab.experiment('service', function() {
           sharedAssertions(script);
 
           // we should not try to su.
-          Lab.expect(script).to.not.match(/su -/);
+          expect(script).to.not.match(/su -/);
 
           // it should populate the bin for the script.
-          Lab.expect(script).to.match(/bin\/node \.\/test.js/)
+          expect(script).to.match(/bin\/node \.\/test.js/)
 
           done();
         });
 
       });
 
-      Lab.it('should switch su to uid user, if uid is provided', function(done) {
+      it('should switch su to uid user, if uid is provided', function(done) {
         Config({
           platform: 'centos',
           daemonsDirectory: './',
@@ -281,7 +285,7 @@ Lab.experiment('service', function() {
           sharedAssertions(script);
 
           // we should try to step down our privileges.
-          Lab.expect(script).to.match(/su - npm/);
+          expect(script).to.match(/su - npm/);
 
           done();
         });
@@ -289,9 +293,9 @@ Lab.experiment('service', function() {
 
     });
 
-    Lab.experiment('ubuntu', function() {
+    lab.experiment('ubuntu', function() {
 
-      Lab.it('should genterate a script with the appropriate variables populated', function(done) {
+      it('should genterate a script with the appropriate variables populated', function(done) {
         Config({
           platform: 'linux',
           daemonsDirectory: './'
@@ -307,7 +311,7 @@ Lab.experiment('service', function() {
           sharedAssertions(script);
 
           // it should populate the bin for the script.
-          Lab.expect(script).to.match(/bin\/node \.\/test.js/)
+          expect(script).to.match(/bin\/node \.\/test.js/)
 
           done();
         });
@@ -315,20 +319,20 @@ Lab.experiment('service', function() {
 
     });
 
-    Lab.it('should raise an appropriate exception if JSON is invalid', function(done) {
+    it('should raise an appropriate exception if JSON is invalid', function(done) {
       Config({
         platform: 'linux',
         daemonsDirectory: './',
         serviceJsonPath: './test/fixtures/invalid-service.json'
       });
 
-      Lab.expect(function() {
+      expect(function() {
         var service = Service.allServices();
       }).to.throw(Error, /invalid service.json, check file for errors/);
       done();
     });
 
-    Lab.it('should pass arguments after -- to generated script', function(done) {
+    it('should pass arguments after -- to generated script', function(done) {
       Config({
         platform: 'linux',
         daemonsDirectory: './'
@@ -346,13 +350,13 @@ Lab.experiment('service', function() {
         sharedAssertions(script);
 
         // it should populate the bin for the script.
-        Lab.expect(script).to.match(/--foovar barvalue/)
+        expect(script).to.match(/--foovar barvalue/)
 
         done();
       });
     });
 
-    Lab.it('should output an array of arguments appropriately to generated script', function(done) {
+    it('should output an array of arguments appropriately to generated script', function(done) {
       Config({
         platform: 'linux',
         daemonsDirectory: './',
@@ -367,13 +371,13 @@ Lab.experiment('service', function() {
         var script = fs.readFileSync(service.scriptPath()).toString();
 
         // it should populate the bin for the script.
-        Lab.expect(script).to.match(/--spider-man sad/)
+        expect(script).to.match(/--spider-man sad/)
 
         done();
       });
     });
 
-    Lab.it('should redirect stderr and stdout to log file by default', function(done) {
+    it('should redirect stderr and stdout to log file by default', function(done) {
       Config({
         platform: 'linux',
         daemonsDirectory: './',
@@ -386,13 +390,13 @@ Lab.experiment('service', function() {
         var script = fs.readFileSync(service.scriptPath()).toString();
 
         // it should redirect script output.
-        Lab.expect(script).to.match(/>>.* 2>&1/);
+        expect(script).to.match(/>>.* 2>&1/);
 
         done();
       });
     });
 
-    Lab.it('should allow stdout/stderr redirect to be overridden by console', function(done) {
+    it('should allow stdout/stderr redirect to be overridden by console', function(done) {
       Config({
         platform: 'linux',
         daemonsDirectory: './',
@@ -405,9 +409,9 @@ Lab.experiment('service', function() {
       service.generateScript(function() {
         var script = fs.readFileSync(service.scriptPath()).toString();
 
-        Lab.expect(script).to.not.match(/>>.* 2>&1/);
+        expect(script).to.not.match(/>>.* 2>&1/);
         // it should use upstart's logging.
-        Lab.expect(script).to.match(/console log/);
+        expect(script).to.match(/console log/);
 
         done();
       });
@@ -415,9 +419,9 @@ Lab.experiment('service', function() {
 
   });
 
-  Lab.experiment('removeScript', function() {
+  lab.experiment('removeScript', function() {
 
-    Lab.it('should remove a generated script', function(done) {
+    it('should remove a generated script', function(done) {
       Config({
         platform: 'darwin',
         daemonsDirectory: './'
@@ -431,7 +435,7 @@ Lab.experiment('service', function() {
           var exists = fs.existsSync(service.scriptPath());
 
           // it should populate the bin for the script.
-          Lab.expect(exists).to.eql(false)
+          expect(exists).to.eql(false)
 
           done();
         });
@@ -439,13 +443,13 @@ Lab.experiment('service', function() {
     });
   });
 
-  Lab.experiment('listScripts', function() {
-    Lab.it('should list scripts provided by service', function(done) {
+  lab.experiment('listScripts', function() {
+    it('should list scripts provided by service', function(done) {
       Config({
         headless: true,
         logger: {
           success: function(msg) {
-            Lab.expect(msg).to.match(/foo/)
+            expect(msg).to.match(/foo/)
             done();
           }
         }
@@ -457,29 +461,29 @@ Lab.experiment('service', function() {
     })
   });
 
-  Lab.experiment('hasScript', function() {
-    Lab.it('returns true if a script exists corresponding to the name provided', function(done) {
+  lab.experiment('hasScript', function() {
+    it('returns true if a script exists corresponding to the name provided', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.hasScript('foo')).to.eql(true);
+      expect(service.hasScript('foo')).to.eql(true);
       done();
     });
 
-    Lab.it('returns false if a script does not exist corresponding to the name provided', function(done) {
+    it('returns false if a script does not exist corresponding to the name provided', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.hasScript('bar')).to.eql(false);
+      expect(service.hasScript('bar')).to.eql(false);
       done();
     });
   });
 
-  Lab.experiment('runScript', function() {
-    Lab.it('should execute matching script for service', function(done) {
+  lab.experiment('runScript', function() {
+    it('should execute matching script for service', function(done) {
       Config({
         headless: true,
         utils: {
           loadServiceJson: require('../lib/utils').loadServiceJson,
           resolve: path.resolve,
           exec: function(cmd, cb) {
-            Lab.expect(cmd).to.match(/\.\/bin\/foo\.js/);
+            expect(cmd).to.match(/\.\/bin\/foo\.js/);
             done();
           }
         }
@@ -489,7 +493,7 @@ Lab.experiment('service', function() {
       service.runScript('foo');
     });
 
-    Lab.it('should not explode if script does not exist', function(done) {
+    it('should not explode if script does not exist', function(done) {
       Config({
         headless: true,
       });
@@ -500,15 +504,15 @@ Lab.experiment('service', function() {
       });
     });
 
-    Lab.it('should execute the script with the appropriate arguments', function(done) {
+    it('should execute the script with the appropriate arguments', function(done) {
       Config({
         headless: true,
         utils: {
           loadServiceJson: require('../lib/utils').loadServiceJson,
           resolve: path.resolve,
           exec: function(cmd, cb) {
-            Lab.expect(cmd).to.match(/--dog also-cute/);
-            Lab.expect(cmd).to.match(/--batman greatest-detective/);
+            expect(cmd).to.match(/--dog also-cute/);
+            expect(cmd).to.match(/--batman greatest-detective/);
             done();
           }
         }
@@ -518,14 +522,14 @@ Lab.experiment('service', function() {
       service.runScript('foo');
     });
 
-    Lab.it('should execute the script with environment variables prepended', function(done) {
+    it('should execute the script with environment variables prepended', function(done) {
       Config({
         headless: true,
         utils: {
           loadServiceJson: require('../lib/utils').loadServiceJson,
           resolve: path.resolve,
           exec: function(cmd, cb) {
-            Lab.expect(cmd).to.match(/PORT="8000"/);
+            expect(cmd).to.match(/PORT="8000"/);
             done();
           }
         }
@@ -535,14 +539,14 @@ Lab.experiment('service', function() {
       service.runScript('foo');
     });
 
-    Lab.it('should pass process.argv arguments to script', function(done) {
+    it('should pass process.argv arguments to script', function(done) {
       Config({
         headless: true,
         utils: {
           loadServiceJson: require('../lib/utils').loadServiceJson,
           resolve: path.resolve,
           exec: function(cmd, cb) {
-            Lab.expect(cmd).to.match(/--timeout=8000/);
+            expect(cmd).to.match(/--timeout 8000/);
             done();
           }
         }
@@ -554,132 +558,132 @@ Lab.experiment('service', function() {
 
   });
 
-  Lab.experiment('_startScript', function() {
-    Lab.it('should remove node bin from the start script', function(done) {
+  lab.experiment('_startScript', function() {
+    it('should remove node bin from the start script', function(done) {
       var service = Service.allServices()[0],
         startScript = service._startScript([]);
 
-      Lab.expect(startScript).to.eql('./test.js');
+      expect(startScript).to.eql('./test.js');
 
       done();
     });
 
-    Lab.it('should add arguments from scripts.start to flatArgs', function(done) {
+    it('should add arguments from scripts.start to flatArgs', function(done) {
       var service = Service.allServices()[0],
         args = ['foo'],
         startScript = service._startScript(args);
 
-      Lab.expect(args[0]).to.eql('convert');
-      Lab.expect(args).to.contain('foo');
+      expect(args[0]).to.eql('convert');
+      expect(args).to.contain('foo');
 
       done();
     });
   });
 
-  Lab.experiment('_fixPath', function() {
-    Lab.it('should replace ./ with absolute path to working directory', function(done) {
+  lab.experiment('_fixPath', function() {
+    it('should replace ./ with absolute path to working directory', function(done) {
       var service = Service.allServices()[0];
 
-      Lab.expect(service._fixPath('./foo')).to.eql(path.resolve('./foo'));
-      Lab.expect(service._fixPath('bar=./foo')).to.eql('bar=' + path.resolve('./foo'));
+      expect(service._fixPath('./foo')).to.eql(path.resolve('./foo'));
+      expect(service._fixPath('bar=./foo')).to.eql('bar=' + path.resolve('./foo'));
 
       done();
     });
 
-    Lab.it('should replace ~/ with absolute path to the home directory', function(done) {
+    it('should replace ~/ with absolute path to the home directory', function(done) {
       var service = Service.allServices()[0];
 
-      Lab.expect(service._fixPath('~/foo')).to.eql(process.env['HOME'] + '/foo');
-      Lab.expect(service._fixPath('bar=~/foo')).to.eql('bar=' + process.env['HOME'] + '/foo');
+      expect(service._fixPath('~/foo')).to.eql(process.env['HOME'] + '/foo');
+      expect(service._fixPath('bar=~/foo')).to.eql('bar=' + process.env['HOME'] + '/foo');
 
       done();
     });
   });
 
-  Lab.experiment('_workingDirectory', function() {
-    Lab.it('uses ./node_modules/<service-name> if not self-referential module', function(done) {
+  lab.experiment('_workingDirectory', function() {
+    it('uses ./node_modules/<service-name> if not self-referential module', function(done) {
       var service = Service.allServices()[0];
-      Lab.expect(service.workingDirectory).to.match(/node_modules\/ndm-test/);
+      expect(service.workingDirectory).to.match(/node_modules\/ndm-test/);
       done();
     });
 
-    Lab.it('uses ./ if self-referential module', function(done) {
+    it('uses ./ if self-referential module', function(done) {
       var service = Service.allServices()[2];
-      Lab.expect(service.workingDirectory).to.eql(path.resolve(__dirname, '../'));
+      expect(service.workingDirectory).to.eql(path.resolve(__dirname, '../'));
       done();
     });
   });
 
-  Lab.experiment('_serviceJsonPath', function() {
-    Lab.it('returns serviceJsonPath if it exists', function(done) {
+  lab.experiment('_serviceJsonPath', function() {
+    it('returns serviceJsonPath if it exists', function(done) {
       var expectedPath = path.resolve(__dirname, '../service.json'),
         config = Config({
           headless: true,
           serviceJsonPath: expectedPath,
         });
 
-      Lab.expect(Service._serviceJsonPath()).to.eql(expectedPath);
-      Lab.expect(config.logsDirectory).to.eql(config.defaultLogsDirectory());
+      expect(Service._serviceJsonPath()).to.eql(expectedPath);
+      expect(config.logsDirectory).to.eql(config.defaultLogsDirectory());
 
       done();
     });
 
-    Lab.it('returns package.json path if no service.json found', function(done) {
+    it('returns package.json path if no service.json found', function(done) {
       var config = Config({
           headless: true,
           serviceJsonPath: path.resolve(__dirname, './fixtures/node_modules/@npm/ndm-test2/service.json')
         });
 
-      Lab.expect(Service._serviceJsonPath()).to.eql(
+      expect(Service._serviceJsonPath()).to.eql(
         path.resolve(__dirname, './fixtures/node_modules/@npm/ndm-test2/package.json')
       );
 
       done();
     });
 
-    Lab.it('finds service in ./node_modules if no service.json found elsewhere', function(done) {
+    it('finds service in ./node_modules if no service.json found elsewhere', function(done) {
       var config = Config({
         headless: true,
         serviceJsonPath: './bin/service.json', // path to service.json that does not exist.
       });
 
-      Lab.expect(Service._serviceJsonPath('ndm-test')).to.match(/\/node_modules\/ndm-test\/service\.json/);
-      Lab.expect(config.serviceJsonPath).to.match(/\/node_modules\/ndm-test\/service\.json/);
-      Lab.expect(config.baseWorkingDirectory).to.match(/\/node_modules\/ndm-test/);
+      expect(Service._serviceJsonPath('ndm-test')).to.match(/\/node_modules\/ndm-test\/service\.json/);
+      expect(config.serviceJsonPath).to.match(/\/node_modules\/ndm-test\/service\.json/);
+      expect(config.baseWorkingDirectory).to.match(/\/node_modules\/ndm-test/);
 
       done();
     });
 
-    Lab.it('falls back to package.json from service.json when installing global module', function(done) {
+    it('falls back to package.json from service.json when installing global module', function(done) {
       var config = Config({
         headless: true,
         serviceJsonPath: './bin/service.json', // path to service.json that does not exist.
       });
 
-      Lab.expect(Service._serviceJsonPath('mocha')).to.match(/\/node_modules\/mocha\/package\.json/);
-      Lab.expect(config.serviceJsonPath).to.match(/\/node_modules\/mocha\/package\.json/);
-      Lab.expect(config.baseWorkingDirectory).to.match(/\/node_modules\/mocha/);
+      expect(Service._serviceJsonPath('mocha')).to.match(/\/node_modules\/mocha\/package\.json/);
+      expect(config.serviceJsonPath).to.match(/\/node_modules\/mocha\/package\.json/);
+      expect(config.baseWorkingDirectory).to.match(/\/node_modules\/mocha/);
 
       done();
     });
 
-    Lab.it('finds service in modulePrefix directory if no service.json found elsewhere', function(done) {
+    it('finds service in modulePrefix directory if no service.json found elsewhere', function(done) {
       var config = Config({
         headless: true,
         modulePrefix: './test/fixtures',
         serviceJsonPath: './bin/service.json', // path to service.json that does not exist.
       });
 
-      Lab.expect(Service._serviceJsonPath('ndm-test')).to.match(
+      expect(Service._serviceJsonPath('ndm-test')).to.match(
         /\/fixtures\/node_modules\/ndm-test\/service\.json/
       );
-      Lab.expect(config.serviceJsonPath).to.match(
+      expect(config.serviceJsonPath).to.match(
         /\/fixtures\/node_modules\/ndm-test\/service\.json/
       );
       done();
     });
 
-    Lab.it('uses os logging directory if service is found using discovery', function(done) {
+    it('uses os logging directory if service is found using discovery', function(done) {
       var config = Config({
         headless: true,
         modulePrefix: './test/fixtures',
@@ -688,11 +692,11 @@ Lab.experiment('service', function() {
 
       Service._serviceJsonPath('ndm-test');
 
-      Lab.expect(config.logsDirectory).to.eql(config.osLogsDirectory);
+      expect(config.logsDirectory).to.eql(config.osLogsDirectory);
       done();
     });
 
-    Lab.it('uses logging directory flag if an override is provided', function(done) {
+    it('uses logging directory flag if an override is provided', function(done) {
       var config = Config({
         headless: true,
         logsDirectory: '/special/logs',
@@ -702,22 +706,22 @@ Lab.experiment('service', function() {
 
       Service._serviceJsonPath('ndm-test');
 
-      Lab.expect(config.logsDirectory).to.eql('/special/logs');
+      expect(config.logsDirectory).to.eql('/special/logs');
       done();
     });
   });
 
-  Lab.experiment('transformPackageJson', function() {
+  lab.experiment('transformPackageJson', function() {
 
-    Lab.it('can load a service from package.json rather than service.json', function(done) {
+    it('can load a service from package.json rather than service.json', function(done) {
       var serviceJson = JSON.parse(fs.readFileSync(
         './node_modules/ndm-test/package.json', 'utf-8'
       ));
 
       var serviceJson = Service.transformPackageJson(serviceJson);
 
-      Lab.expect(Object.keys(serviceJson)[0]).to.eql('ndm-test');
-      Lab.expect(serviceJson['ndm-test'].scripts.start).to.eql('node ./test.js');
+      expect(Object.keys(serviceJson)[0]).to.eql('ndm-test');
+      expect(serviceJson['ndm-test'].scripts.start).to.eql('node ./test.js');
 
       done();
     });


### PR DESCRIPTION
Added a `lab.script()` line to the top of each test file & tweaked the references to `expect` to match the new exposed API. Updated the timeout command-line option to use the new syntax (no `=`) and tweaked a test that relied on that syntax.

No functional changes.
