### PR TITLE
Export variables separately in init.d

### DIFF
--- a/templates/init-d.ejs
+++ b/templates/init-d.ejs
@@ -14,7 +14,11 @@
 
 dir="<%- workingDirectory %>"
 user="<%- uid %>"
-cmd="<% Object.keys(env).forEach(function(key) {%><%- key %>=<%- env[key] %> <% }); %><%- nodeBin %> <%- startScript %><% flatArgs.forEach(function(arg) { %> <%- arg %><% }); %>"
+<% Object.keys(env).forEach(function (key) { %>
+<%- key %>=<%- env[key] %>
+export <%- key %>
+<% }) %>
+cmd="<%- nodeBin %> <%- startScript %><% flatArgs.forEach(function(arg) { %> <%- arg %><% }); %>"
 
 name=`basename $0`
 pid_file="/var/run/$name.pid"


### PR DESCRIPTION
This allows commands to have variables in their arguments, like `cmd
$PORT`

Feedback welcome -- this does pollute the internals of the init script more, and I'm not sure if there's way to get feature parity in other init systems.