### PR TITLE
properly escape xml characters in .plist files

### DIFF
--- a/lib/platform-apis/platform-base.js
+++ b/lib/platform-apis/platform-base.js
@@ -1,7 +1,8 @@
 var _ = require('lodash'),
   ejs = require('ejs'),
   fs = require('fs'),
-  rimraf = require('rimraf');
+  rimraf = require('rimraf'),
+  xmlescape = require('xml-escape');
 
 // An API for executing OS-specific commands,
 // and generating OS-specific daemon scripts.
@@ -33,7 +34,8 @@ PlatformBase.prototype.generateServiceScript = function(service, args, cb) {
       service.scriptPath(),
       ejs.render(fs.readFileSync(this.template).toString(), _.merge({}, service, {
         startScript: service._startScript(args),
-        flatArgs: args
+        flatArgs: args,
+        xmlescape: xmlescape
       })),
       {
         mode: 0755

--- a/lib/platform-apis/platform-base.js
+++ b/lib/platform-apis/platform-base.js
@@ -35,7 +35,10 @@ PlatformBase.prototype.generateServiceScript = function(service, args, cb) {
       ejs.render(fs.readFileSync(this.template).toString(), _.merge({}, service, {
         startScript: service._startScript(args),
         flatArgs: args,
-        xmlescape: xmlescape
+        xmlescape: function(s) {
+          if (typeof s === 'string') return xmlescape(s);
+          else return s;
+        }
       })),
       {
         mode: 0755

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "string": "^1.8.1",
     "temp": "^0.8.1",
     "yargs": "^3.0.4"
+    "xml-escape": "^1.0.0"
   },
   "devDependencies": {
     "lab": "~4.5.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "rimraf": "^2.2.8",
     "string": "^1.8.1",
     "temp": "^0.8.1",
-    "yargs": "^3.0.4"
+    "yargs": "^3.0.4",
     "xml-escape": "^1.0.0"
   },
   "devDependencies": {

--- a/templates/launchctl.ejs
+++ b/templates/launchctl.ejs
@@ -5,17 +5,17 @@
     <key>KeepAlive</key>
     <true/>
     <key>Label</key>
-    <string><%- name %></string>
+    <string><%- xmlescape(name) %></string>
     <key>ProgramArguments</key>
     <array>
       <string><%- nodeBin %></string>
       <string><%- startScript %></string><% flatArgs.forEach(function(arg) { %>
-      <string><%- arg %></string><% }); %>
+      <string><%- xmlescape(arg) %></string><% }); %>
     </array>
     <key>EnvironmentVariables</key>
     <dict><% Object.keys(env).forEach(function(key) { %>
-      <key><%- key %></key>
-      <string><%- env[key] %></string><% }); %>
+      <key><%- xmlescape(key) %></key>
+      <string><%- xmlescape(env[key]) %></string><% }); %>
     </dict>
     <key>EnableTransactions</key>
     <true/>

--- a/test/fixtures/bad-xml-service.json
+++ b/test/fixtures/bad-xml-service.json
@@ -1,0 +1,26 @@
+{
+  "ndm-test": {
+    "scripts": {
+      "start": "./test.js"
+    },
+    "module": "ndm-test",
+    "env": {
+      "PORT": "8000</string>",
+      "HOST": {
+        "default": "localhost",
+        "description": "what host should I bind to?"
+      }
+    },
+    "args": [
+      "--apple",
+      "banana",
+      "--spider-man",
+      "sad",
+      "awesome"
+    ]
+  },
+  "args": [
+    "a",
+    "b"
+  ]
+}

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -285,9 +285,6 @@ lab.experiment('service', function() {
       // global ags variables populated.
       expect(script).to.match(/--batman/);
       expect(script).to.match(/greatest-detective/);
-
-      // does not escape special characters such as "'".
-      expect(script).to.match(/'awesome'/);
     }
 
     lab.experiment('darwin', function() {
@@ -364,6 +361,9 @@ lab.experiment('service', function() {
           // it should populate the bin for the script.
           expect(script).to.match(/(bin\/node \.\/test.js)|(bin\/iojs \.\/test.js)/);
 
+          // does not escape special characters such as "'".
+          expect(script).to.match(/'awesome'/);
+
           done();
         });
 
@@ -414,6 +414,9 @@ lab.experiment('service', function() {
           // it should populate the bin for the script.
           expect(script).to.match(/(bin\/node \.\/test.js)|(bin\/iojs \.\/test.js)/);
           expect(script).to.match(/description ".*"/);
+
+          // does not escape special characters such as "'".
+          expect(script).to.match(/'awesome'/);
 
           done();
         });

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -316,6 +316,31 @@ lab.experiment('service', function() {
       });
     });
 
+    lab.experiment('darwin', function() {
+      it('should genterate valid xml', function(done) {
+        // test generating a script for darwin.
+        Config({
+          platform: 'darwin',
+          daemonsDirectory: './',
+          serviceJsonPath: './test/fixtures/bad-xml-service.json'
+        }, true);
+
+        var service = Service.allServices()[0];
+
+        service.generateScript(function() {
+          // inspect the generated script, and make sure we've
+          // populated the appropriate stanzas.
+          var script = fs.readFileSync(service.scriptPath()).toString();
+
+          // the number of starting and closing tags should be the same
+          expect(script.match(/<string>/g).length).to.equal(script.match(/<\/string>/g).length)
+
+          done();
+        });
+
+      });
+    });
+
     lab.experiment('centos', function() {
 
       it('should generate a script with the appropriate variables populated', function(done) {

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -314,9 +314,7 @@ lab.experiment('service', function() {
         });
 
       });
-    });
 
-    lab.experiment('darwin', function() {
       it('should genterate valid xml', function(done) {
         // test generating a script for darwin.
         Config({
@@ -334,6 +332,8 @@ lab.experiment('service', function() {
 
           // the number of starting and closing tags should be the same
           expect(script.match(/<string>/g).length).to.equal(script.match(/<\/string>/g).length)
+          // should have escaped < character.
+          expect(script).to.match(/&lt;/);
 
           done();
         });


### PR DESCRIPTION
Characters such as `<` created invalid `.plist` files, see: https://github.com/npm/ndm/pull/102