### PR TITLE
make it so you can specify a uuid placeholder

### DIFF
--- a/lib/interview.js
+++ b/lib/interview.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
   Service = require('./service'),
-  utils = require('./utils');
+  utils = require('./utils'),
+  uuid = require('node-uuid');
 
 // ask the user to fill in any variables in
 // the service.json of the form <description of value>.
@@ -144,9 +145,9 @@ Interview.prototype._addQuestion = function(uniqueKey, parent) {
 
     this.questionLookup[uniqueKey] = {
       key: key, // key to modify in original JSON.
-      parent: parent, // node in a original JSON to modify,
+      parent: parent, // node in original JSON to modify,
       message: value.description, // description for inquirer.
-      default: value.default || '' // default value to display.
+      default: (value.default || '').replace('{{uuid}}', uuid.v4()) // default value to display.
     };
   };
 };

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "inquirer": "^0.5.1",
     "lodash": "^2.4.1",
     "mkdirp": "^0.5.0",
+    "node-uuid": "^1.4.3",
     "npmconf": "^1.1.5",
     "rc": "^0.4.0",
     "rimraf": "^2.2.8",
     "string": "^1.8.1",
     "temp": "^0.8.1",
     "xml-escape": "^1.0.0",
-    "yargs": "^3.2.1"
+    "yargs": "^3.8.0"
   },
   "devDependencies": {
     "lab": "~4.5.1",

--- a/service.json
+++ b/service.json
@@ -31,6 +31,10 @@
       "HOST": {
         "default": "localhost",
         "description": "what host should I bind to?"
+      },
+      "SECRET": {
+        "default": "{{uuid}}",
+        "description": "a unique value"
       }
     },
     "args": [

--- a/test/interview-test.js
+++ b/test/interview-test.js
@@ -73,6 +73,34 @@ Lab.experiment('interview', function() {
 
       done();
     });
+
+    Lab.describe('default values', function() {
+      Lab.it('should load default values', function(done) {
+        var interview = new Interview();
+
+        interview._generateQuestions();
+
+        // we handle two keys colliding by using a longer unique key.
+        expect(
+          interview.questionLookup['HOST'].default
+        ).to.eql('localhost');
+
+        done();
+      });
+
+      Lab.it('should replace {{uuid}} with a GUID', function(done) {
+        var interview = new Interview();
+
+        interview._generateQuestions();
+
+        // we handle two keys colliding by using a longer unique key.
+        expect(
+          interview.questionLookup['SECRET'].default
+        ).to.match(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/);
+
+        done();
+      });
+    });
   });
 
   Lab.experiment('run', function() {


### PR DESCRIPTION
Made it so during the interview process, you can specify that a default value should be a randomly generated `uuid`. This addresses a security concern, regarding uuids defaulting to the same value:

https://github.com/npm/security/issues/38