### PR TITLE
use exec to unwrap upstart pids, avoid fork detection madness

### DIFF
--- a/templates/upstart-centos.ejs
+++ b/templates/upstart-centos.ejs
@@ -9,5 +9,5 @@ limit nofile 1000000 1000000
 script<% if (uid) { %>
   su - <%- uid %><% } %>
   cd <%- workingDirectory %>
-  <% Object.keys(env).forEach(function(key) {%><%- key %>=<%- env[key] %> <% }); %><%- nodeBin %><% nodeFlags.forEach(function(flag) { %> <%- flag %><% }); %> <%- startScript %><% flatArgs.forEach(function(arg) { %> <%- arg %><% }); %> >> <%- logFile %> 2>&1
+  exec <% Object.keys(env).forEach(function(key) {%><%- key %>=<%- env[key] %> <% }); %><%- nodeBin %><% nodeFlags.forEach(function(flag) { %> <%- flag %><% }); %> <%- startScript %><% flatArgs.forEach(function(arg) { %> <%- arg %><% }); %> >> <%- logFile %> 2>&1
 end script

--- a/templates/upstart-ubuntu.ejs
+++ b/templates/upstart-ubuntu.ejs
@@ -26,5 +26,5 @@ limit core unlimited unlimited
 
 script
   cd <%- workingDirectory %>
-  <% Object.keys(env).forEach(function(key) {%><%- key %>=<%- env[key] %> <% }); %><%- nodeBin %><% nodeFlags.forEach(function(flag) { %> <%- flag %><% }); %> <%- startScript %><% flatArgs.forEach(function(arg) { %> <%- arg %><% }); %><% if (!console) { %> >> <%- logFile %> 2>&1 <% } %>
+  exec <% Object.keys(env).forEach(function(key) {%><%- key %>=<%- env[key] %> <% }); %><%- nodeBin %><% nodeFlags.forEach(function(flag) { %> <%- flag %><% }); %> <%- startScript %><% flatArgs.forEach(function(arg) { %> <%- arg %><% }); %><% if (!console) { %> >> <%- logFile %> 2>&1 <% } %>
 end script


### PR DESCRIPTION
right now there is a parent pid, can cause problems if the child iojs/node process is killed using pid shown in `status $service`, this will leave a zombie. Fixed by using `exec` sh builtin.
