### PR TITLE
initd: Add service name to LSB comment

### DIFF
--- a/templates/init-d.ejs
+++ b/templates/init-d.ejs
@@ -1,9 +1,9 @@
+#!/bin/sh
 # Thanks to Felix H. Dahlke (https://github.com/fhd)
 # for providing this great init.d template.
 #
-#!/bin/sh
 ### BEGIN INIT INFO
-# Provides:
+# Provides:          <%- name %>
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
`update-rc.d` complained that the LSB comment was missing a valid *provides* value.

```
$ update-rc.d -f test-service defaults
update-rc.d: using dependency based boot sequencing
insserv: Script test-service is broken: incomplete LSB comment.
insserv: missing valid name for `Provides:' please add.
```